### PR TITLE
Docker setup for running Airflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM apache/airflow:2.8.1
+
+WORKDIR /app
+
+RUN pip install -U pip --upgrade pip
+
+# TODO: Change this permission. 777 isnt safe
+COPY --chown=0 --chmod=777 . /app
+
+RUN pip install -r ./requirements.txt
+RUN python setup.py sdist
+RUN python setup.py install --user

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,14 +18,15 @@ x-airflow-common:
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.session'
     AIRFLOW__SECRETS__BACKEND: airflow.secrets.local_filesystem.LocalFilesystemBackend
     AIRFLOW__SECRETS__BACKEND_KWARGS: '{"variables_file_path": "/opt/secrets/variables.yaml", "connections_file_path": "/opt/secrets/connections.yaml"}'
+    AIRFLOW_UID: ${AIRFLOW_UID:-501}
   volumes:
-    - ${AIRFLOW_DAGS}:/opt/airflow/dags
-    - ${AIRFLOW_LOGS}:/opt/airflow/logs
-    - ${AIRFLOW_PLUGINS}:/opt/airflow/plugins
-    - ${AIRFLOW_SECRETS}:/opt/secrets
+    - ${AIRFLOW_PROJ_DIR:-./src/mlcore/pipeline/airflow}/dags:/opt/airflow/dags
+    - ${AIRFLOW_PROJ_DIR:-./src/mlcore/pipeline/airflow}/logs:/opt/airflow/logs
+    - ${AIRFLOW_PROJ_DIR:-./src/mlcore/pipeline/airflow}/plugins:/opt/airflow/plugins
+    - ${AIRFLOW_PROJ_DIR:-./src/mlcore/pipeline/airflow}/secrets:/opt/secrets
   networks:
     - airflow
-  user: "${AIRFLOW_UID:-50000}:0"
+  user: "${AIRFLOW_UID:-501}:0"
   depends_on:
     &airflow-common-depends-on
     postgres:
@@ -154,7 +155,7 @@ services:
       _PIP_ADDITIONAL_REQUIREMENTS: ''
     user: "0:0"
     volumes:
-      - .:/sources
+      - ./src/mlcore/pipeline/airflow:/sources
 
 networks:
     airflow:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ Flask
 Flask-Cors
 librosa
 optuna
--e .
+# -e .

--- a/src/mlcore/pipeline/airflow/Dockerfile
+++ b/src/mlcore/pipeline/airflow/Dockerfile
@@ -1,6 +1,0 @@
-FROM apache/airflow:2.8.1
-
-WORKDIR /opt/airflow
-RUN pip install -U pip --upgrade pip
-COPY . .
-RUN pip install -r ./requirements.txt


### PR DESCRIPTION
I added the new dockerfile and docker-compose.yaml files.

You can now start the container from local and it will install mlcore inside the container. This means airflow should be able to use the mlcore package inside the container. Future commits should try to achieve this.